### PR TITLE
Fix/start kill active server

### DIFF
--- a/features/configurations/configurations-cli.js
+++ b/features/configurations/configurations-cli.js
@@ -19,7 +19,8 @@ function beforeInstall(config, utils, next) {
     private: config.install.private,
     scripts: {
       prestart: 'npm install',
-      start: 'node start'
+      start: 'node start.js',
+      stop: 'node stop.js'
     }
   }, config.package);
 

--- a/features/configurations/configurations-cli.js
+++ b/features/configurations/configurations-cli.js
@@ -28,6 +28,7 @@ function beforeInstall(config, utils, next) {
 
   utils.copy(path.join(source, 'ignore'), path.resolve(utils.path, '.gitignore'));
   utils.copy(path.join(source, 'start.js'), path.resolve(utils.path, 'start.js'));
+  utils.copy(path.join(source, 'stop.js'), path.resolve(utils.path, 'stop.js'));
 
   if (!fs.existsSync(path.resolve(utils.path, 'README.md'))) {
     var readme = utils.getContent(path.join(source, 'README.md')),

--- a/features/configurations/resources/ignore
+++ b/features/configurations/resources/ignore
@@ -12,5 +12,6 @@ build/Release
 .lock-wscript
 .env
 public
-pid
+.pid
+.gulppid
 Thumbs.db

--- a/features/configurations/resources/start.js
+++ b/features/configurations/resources/start.js
@@ -1,21 +1,15 @@
 'use strict';
 
-var fs = require('fs'),
-    execSync = require('child_process').execSync,
-    forever = require('forever-monitor'),
-    pidFile = 'pid',
-    pid = fs.existsSync(pidFile) ? fs.readFileSync(pidFile, 'utf-8') : null;
+var PID_FILE = '.pid',
 
-if (pid) {
-  try {
-    fs.unlinkSync(pidFile);
-    execSync('kill -TERM -' + pid + ' 2>&1');
-  }
-  catch (ex) {}
-}
+    fs = require('fs'),
+    execSync = require('child_process').execSync,
+    forever = require('forever-monitor');
+
+execSync('node stop.js');
 
 execSync('node evolve.js');
 
-var child = forever.start(['env', 'gulp'], {});
+forever.start(['env', 'gulp'], {});
 
-fs.writeFileSync('pid', child.child.pid);
+fs.writeFileSync(PID_FILE, process.pid);

--- a/features/configurations/resources/stop.js
+++ b/features/configurations/resources/stop.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var PID_FILE = '.pid',
+    GULP_PID_FILE = '.gulppid',
+
+    fs = require('fs'),
+    forever = require('forever-monitor'),
+    pid = fs.existsSync(PID_FILE) ? fs.readFileSync(PID_FILE, 'utf-8') : null,
+    gulppid = fs.existsSync(GULP_PID_FILE) ? fs.readFileSync(GULP_PID_FILE, 'utf-8') : null;
+
+if (pid) {
+  try {
+    fs.unlinkSync(PID_FILE);
+    forever.kill(pid);
+  }
+  catch (ex) {}
+}
+
+if (gulppid) {
+  try {
+    fs.unlinkSync(GULP_PID_FILE);
+    forever.kill(gulppid);
+  }
+  catch (ex) {}
+}

--- a/features/views/resources/gulpfile.js
+++ b/features/views/resources/gulpfile.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var fs = require('fs'),
+var PID_FILE = '.gulppid',
+
+    fs = require('fs'),
     dotenv = require('dotenv');
 
 if (!fs.existsSync('.env')) {
@@ -8,6 +10,8 @@ if (!fs.existsSync('.env')) {
 }
 
 dotenv.load();
+
+fs.writeFileSync(PID_FILE, process.pid);
 
 var Plumes = require('plumes'),
     gulp = require('gulp'),


### PR DESCRIPTION
## Details

This save the forever-monitor PID instance to .pid file and the gulp PID instance to .gulppid file.
The new `npm stop` command calls the _stop.js_ script. It kills instances saved in the PID files.
The _start.js_ script start by calling the _stop.js_ file.

Issue: https://github.com/CodeCorico/allons-y/issues/3
