### PR TITLE
Fix/models unrefreshed

### DIFF
--- a/features/models/resources/common-async-gulpfile.js
+++ b/features/models/resources/common-async-gulpfile.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var sourcemaps = require('gulp-sourcemaps'),
+    uglify = require('gulp-uglify'),
+    rename = require('gulp-rename');
+
+module.exports = function asyncDependencies(gulp) {
+
+  gulp.task('asyncDependencies', function(done) {
+    gulp
+      .src(['node_modules/async/lib/async.js'])
+      .pipe(gulp.dest('./public/vendor'))
+      .pipe(sourcemaps.init())
+      .pipe(uglify())
+      .pipe(rename({
+        extname: '.min.js'
+      }))
+      .pipe(sourcemaps.write('./'))
+      .pipe(gulp.dest('./public/vendor'))
+      .on('end', done);
+  });
+
+  return 'asyncDependencies';
+};

--- a/features/models/resources/common-events-manager-gulpfile.js
+++ b/features/models/resources/common-events-manager-gulpfile.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function eventsManagerDependencies(gulp) {
+
+  gulp.task('eventsManagerDependencies', function(done) {
+    gulp.src([
+      'node_modules/events-manager/events-manager.js',
+      'node_modules/events-manager/events-manager.min.js'
+    ])
+      .pipe(gulp.dest('./public/vendor'))
+      .on('end', done);
+  });
+
+  return 'eventsManagerDependencies';
+};

--- a/features/models/resources/common-models-gulpfile.js
+++ b/features/models/resources/common-models-gulpfile.js
@@ -45,30 +45,7 @@ module.exports = function modelsDependencies(gulp) {
 
         return filePath.join(path.sep);
       }))
-      .on('end', function() {
-
-        gulp
-          .src(['node_modules/async/lib/async.js'])
-          .pipe(gulp.dest('./public/vendor'))
-          .pipe(sourcemaps.init())
-          .pipe(uglify())
-          .pipe(rename({
-            extname: '.min.js'
-          }))
-          .pipe(sourcemaps.write('./'))
-          .pipe(gulp.dest('./public/vendor'))
-          .on('end', function() {
-
-            gulp.src([
-              'node_modules/events-manager/events-manager.js',
-              'node_modules/events-manager/events-manager.min.js'
-            ])
-              .pipe(gulp.dest('./public/vendor'))
-              .on('end', done);
-
-          });
-
-      });
+      .on('end', done);
   });
 
   return {

--- a/features/models/resources/common-models-gulpfile.js
+++ b/features/models/resources/common-models-gulpfile.js
@@ -17,6 +17,8 @@ module.exports = function modelsDependencies(gulp) {
   gulp.task('modelsDependencies', function(done) {
 
     glob.sync(path.join(modelsPath, filesPattern)).forEach(function(file) {
+      delete require.cache[require.resolve(file)];
+
       var filePathArray = file.split('/'),
           filename = filePathArray.pop(),
           feature = filePathArray.pop() ? filePathArray.pop() : null,


### PR DESCRIPTION
## Problem

When the plateform is live, a gulp watcher is used to refresh files from new dev modifications. But for models files, the task don't works the same way.
## Solution

The modelsDependency task use `require()` to load model files then create a new /public function file. But _require_ keep a cache of the loaded files. So if the file is updated, _require_ don't reload it.
This PR delete the _require_ cache before loading the file.

This PR adds a refactor by spliting the modelsDependency taks in 3 independant tasks.
