### PR TITLE
Fix/index project name

### DIFF
--- a/features/controllers/resources/project-index-20-express.js
+++ b/features/controllers/resources/project-index-20-express.js
@@ -2,7 +2,7 @@
 
 var path = require('path'),
     fileName = path.basename(__filename),
-    projectName = fileName.split('-')[0];
+    projectName = fileName.replace('-index-20-express.js', '');
 
 module.exports = ['$server', function($server) {
   $server.use(function(req, res) {


### PR DESCRIPTION
## How to reproduce
- I create a new project named "my-project"
- I start the server with `gulp`
- :boom: Impossible to start the index page
## Solution

The index page now support to have a _-_ in the project name
